### PR TITLE
fix(web): increase timeout to detect `cancel`

### DIFF
--- a/src/web.ts
+++ b/src/web.ts
@@ -57,7 +57,7 @@ export class FilePickerWeb extends WebPlugin implements FilePickerPlugin {
       window.addEventListener(
         'focus',
         async () => {
-          await this.wait(300);
+          await this.wait(1000);
           if (onChangeFired) {
             return;
           }


### PR DESCRIPTION
On some (slow) devices the timeout was too short, so that no files could be selected.