### PR TITLE
fix(android): add fallback for file name

### DIFF
--- a/android/src/main/java/dev/robingenz/capacitorjs/plugins/filepicker/FilePicker.java
+++ b/android/src/main/java/dev/robingenz/capacitorjs/plugins/filepicker/FilePicker.java
@@ -42,6 +42,9 @@ public class FilePicker {
             displayName = cursor.getString(columnIdx);
             cursor.close();
         }
+        if (displayName == null || displayName.length() < 1) {
+            displayName = uri.getLastPathSegment();
+        }
         return displayName;
     }
 


### PR DESCRIPTION
> The human-friendly name of file. If this is not provided then the name should default to the the last segment of the file's URI.

See https://developer.android.com/reference/android/provider/OpenableColumns#DISPLAY_NAME